### PR TITLE
Scale elements to fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,6 @@ With the following options:
 ### Layout and Styling
 The most part of the styling happens in the `piano_style.css`. You can overwrite the style or change them directly to change the appearance of the keyboard.
 
-
-## Known Issues
-### Keyboard size
-Currently the keyboard / key size is set fixed in the `piano_style.css`.
-
-If you have an idea how to make the keyboard scale depending on its container size, please create a pull request.
-
 # License and Contribution
 pianoKeyboard was developed by Anna Neovesky and 
 Gabriel Reimers at the [Digital Academy](https://www.digitale-akademie.de) of the [Academy of Sciences and Literatur | Mainz](https://www.adwmainz.de)

--- a/piano.js
+++ b/piano.js
@@ -221,30 +221,29 @@ function htmlForClefSelection() {
 function htmlForNotesSelection() {
     var html = ''
 
-    html += '\n\
-    <div id="DA-NoteSelection" class="DA-NoteClefSelection">\n\
-        <input type="radio" name="notes" id="note-1-1" value="1">\n\
-        <label for="note-1-1" >1/1</label>\n\
-        \
-        <input type="radio" name="notes" id="note-1-2" value="2">\n\
-        <label for="note-1-2" >1/2</label>\n\
-        \
-        <input type="radio" name="notes" id="note-1-4" checked value="4">\n\
-        <label for="note-1-4" >1/4</label>\n\
-        \
-        <input type="radio" name="notes" id="note-1-8" value="8">\n\
-        <label for="note-1-8" >1/8</label>\n\
-        \
-        <input type="radio" name="notes" id="note-1-16" value="6">\n\
-        <label for="note-1-16" >1/16</label>\n\
-        \
-        <input type="radio" name="notes" id="note-1-32" value="3">\n\
-        <label for="note-1-32" >1/32</label>\n\
-    </div>'
+    html += 
+    '<div id="DA-NoteSelection" class="DA-NoteClefSelection">'+
+        '<input type="radio" name="notes" id="note-1-1" value="1">'+
+        '<label for="note-1-1" >1/1</label>'+
+
+        '<input type="radio" name="notes" id="note-1-2" value="2">'+
+        '<label for="note-1-2" >1/2</label>'+
+
+        '<input type="radio" name="notes" id="note-1-4" checked value="4">'+
+        '<label for="note-1-4" >1/4</label>'+
+
+        '<input type="radio" name="notes" id="note-1-8" value="8">'+
+        '<label for="note-1-8" >1/8</label>'+
+
+        '<input type="radio" name="notes" id="note-1-16" value="6">'+
+        '<label for="note-1-16" >1/16</label>'+
+        
+        '<input type="radio" name="notes" id="note-1-32" value="3">'+
+        '<label for="note-1-32" >1/32</label>'+
+    '</div>'
 
     return html
 }
-
 
 
 

--- a/piano_style.css
+++ b/piano_style.css
@@ -1,47 +1,61 @@
+#keyboardContainer {
+    font: 1.1vw Lucida Sans, Trebuchet MS, Tahoma, sans-serif;
+}
+
 .DA-Keyboardcontainer {
-    font: 16px Lucida Sans, Trebuchet MS, Tahoma, sans-serif;
     color: #000;
-    padding: 20px;
+    margin: 2em;
+    height:15em;
+    display: inline-block;
 }
 
 ul.DA-PianoKeyboard {
-    position: relative;
     display: inline-block;
-    height:160px;
     padding: 0;
     cursor: pointer;
     list-style-type: none;
 }
 
 ul.DA-PianoKeyboard li {
+    box-sizing: border-box;
+    float:left;
     position: relative;
-    float: left;
     border-style: solid;
     border-color: #000;
-    border-width: 2px 1px 2px 1px;
-    border-radius: 0 0 4px 4px;
+    border-width: 0.2em 0.1em 0.2em 0.1em;
+    border-radius: 0 0 0.4em 0.4em;
     color: #ccc;
     text-align: center;
 }
 
-.whiteKey>p {
-    margin-top: 120px;
+li>p {
+    font-size: 1.6em;
+    margin: 0;
 }
 
 ul.DA-PianoKeyboard li:first-of-type {
-    border-left-width: 2px;
-    border-top-left-radius: 4px;
+    border-left-width: 0.2em;
+    border-top-left-radius: 0.4em;
 }
 
 ul.DA-PianoKeyboard li:last-of-type {
-    border-right-width: 2px;
-    border-top-right-radius: 4px;
+    border-right-width: 0.2em;
+    border-top-right-radius: 0.4em;
 }
 
 .whiteKey {
-    width: 30px;
-    height: 150px;
+    width: 3em;
+    height: 15em;
     background: #fff;
+    padding-top: 12em;
+}
+
+.blackKeySharp, .blackKeyFlat {
+    z-index: 1;
+    width: 2em;
+    height: 5em;
+    margin: 0 -1em 0-1em;
+    padding-top: 1em;
 }
 
 .whiteKey:hover:active {
@@ -52,64 +66,43 @@ ul.DA-PianoKeyboard li:last-of-type {
     background: #f9f9f9;
 }
 
-.blackKeySharp {
-    background: #000;
-    z-index: 10;
-    width: 20px;
-    height: 50px;
-    margin: 0 0 0 -10px;
-}
 
-.blackKeySharp:hover:active {
+.blackKeySharp:hover:active, .blackKeyFlat:hover:active {
     background: #555;
 }
 
-.blackKeySharp:hover {
+.blackKeySharp:hover, .blackKeyFlat:hover {
     background: #444;
+}
+
+.blackKeySharp {
+    background: #000;
 }
 
 .blackKeyFlat {
-    top: 50px;
+    top: 4em;
     background: #111;
-    z-index: 10;
-    width: 20px;
-    height: 50px;
-    margin: 0 0 0 -10px;
-}
-
-.blackKeyFlat:hover:active {
-    background: #555;
-}
-
-.blackKeyFlat:hover {
-    background: #444;
-}
-
-/* positioning */
-
-.blackKeyFlat + .whiteKey {
-    margin-left: -12px;
-}
-
-.blackKeySharp + .blackKeyFlat{
-    margin-left: -22px;
 }
 
 
 /* Octave shift */
 
-.DA-Keyboardcontainer button {
-    display: inline-block;
-    cursor: pointer;
-    background-color: rgba(255, 255, 255, 0.0);
-    margin: 10px;
-    border-style: none;
-    padding: 10px;
-    text-align: center;
+.DA-Keyboardcontainer button{
+    font-size: 5em;
     vertical-align: top;
-    font-size: 50px;
-    height: 160px;
+    margin: 0.2em;
+    padding: 0.2em;
+    height: 3em;
+    border-style: none;
+    background-color: transparent;
+    display: inline-block;
+    text-align: center;
     color: #999;
+    cursor: pointer;
+}
+
+.DA-Keyboardcontainer button:disabled{
+    visibility: hidden;
 }
 
 .DA-Keyboardcontainer button:hover {
@@ -117,38 +110,31 @@ ul.DA-PianoKeyboard li:last-of-type {
 }
 
 
-.DA-Keyboardcontainer button:disabled {
-    color: #fff;
-    cursor: default;
-}
-
-.DA-Keyboardcontainer button:disabled:hover {
-    background-color: #fff;
-}
-
-
 /* Notes Selection */
 
 #DA-NoteSelection {
     display: inline-block;
-    margin-left: 50px;
-    height: 40px;
+    margin-left: 2.5em;
+    height: 2em;
+}
+
+.DA-NoteClefSelection *{
+    font-size: 1.5em;
 }
 
 .DA-NoteClefSelection input[type=radio] {
     display: none;
-    margin: 0px
 }
 
 .DA-NoteClefSelection input[type=radio] + label {
-    font: 16px Lucida Sans, Trebuchet MS, Tahoma, sans-serif;
     display: inline-block;
     background: #fff;
     color: #000;
-    padding: 10px;
-    border: 2px solid #000;
-    border-radius: 2px;
-    margin-left: -6px; /* There is some margin, which I don't know where it comes from... */
+    padding: 0.5em;
+    border: 0.1em solid #000;
+    border-radius: 0.1em;
+    margin-left: -0.05em;
+    /* margin-left: -6px; Margin is due to white space in html */
 }
 
 .DA-NoteClefSelection input[type=radio]:checked + label {
@@ -160,10 +146,6 @@ ul.DA-PianoKeyboard li:last-of-type {
 /* Clef Selection */
 
 #DA-ClefSelection {
-
     display: inline-block;
-    margin-left: 200px;
-    height: 40px;
+    margin-left: 20em;
 }
-
-


### PR DESCRIPTION
Elements are now styled according to viewport width. Adjusting viewport width causes the size of the toolbars to scale accordingly. This would fix Issue #1 by @greimers .

JS was updated to remove newlines which cause whitespace between radiobutton elements. However, it would be better if 

> document.createElement()

 was used instead of HTML in strings to avoid similar problems in the future.